### PR TITLE
Use Scan to Build and use released version of Quick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ tmp
 # `pod install` in .travis.yml
 #
 # Pods/
+
+#scan
+test_output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@
 The Pact Consumer Swift library is using carthage to manage library dependencies. You can install carthage using homebrew, then download and build the dependencies using `carthage bootstrap`
 
 ### Running tests
-`xcodebuild -project PactConsumerSwift.xcodeproj -scheme PactConsumerSwift test -sdk iphonesimulator8.1`
+`scan`
 
 For more information, see the .travis.yml

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,3 @@
-
 github "Alamofire/Alamofire" ~> 4.0
 github "Thomvis/BrightFutures" ~> 5.0
 github "Quick/Nimble" ~> 5.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "Quick/Quick" "master"
+github "Quick/Quick" ~> 0.10.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-github "Alamofire/Alamofire" "4.0.0"
+github "Alamofire/Alamofire" "4.0.1"
 github "Quick/Nimble" "v5.0.0"
-github "Quick/Quick" "e72d6dc86bea6b0200a54c86820a6407cf20ebb0"
+github "Quick/Quick" "v0.10.0"
 github "antitypical/Result" "3.0.0"
 github "Thomvis/BrightFutures" "v5.0.1"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'pact-mock_service', '~> 0.9.0'
-gem 'xcpretty'
+gem 'scan', '~> 0.13.0'
+gem 'pact-mock_service', '~> 0.10.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,37 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    awesome_print (1.6.1)
+    awesome_print (1.7.0)
+    babosa (1.0.2)
+    colored (1.2)
+    commander (4.4.0)
+      highline (~> 1.7.2)
+    credentials_manager (0.16.0)
+      colored
+      commander (>= 4.3.5)
+      highline (>= 1.7.1)
+      security
     diff-lcs (1.2.5)
+    excon (0.45.4)
+    fastlane_core (0.52.0)
+      babosa
+      colored
+      commander (>= 4.4.0, <= 5.0.0)
+      credentials_manager (>= 0.16.0, < 1.0.0)
+      excon (~> 0.45.0)
+      gh_inspector (>= 1.0.1, < 2.0.0)
+      highline (>= 1.7.2)
+      json
+      multi_json
+      plist (~> 3.1)
+      rubyzip (~> 1.1.6)
+      terminal-table (~> 1.4.5)
     find_a_port (1.0.1)
+    gh_inspector (1.0.2)
+    highline (1.7.8)
     json (1.8.3)
-    pact-mock_service (0.9.0)
+    multi_json (1.12.1)
+    pact-mock_service (0.10.2)
       find_a_port (~> 1.0.1)
       json
       pact-support (~> 0.5.8)
@@ -15,7 +41,7 @@ GEM
       term-ansicolor (~> 1.0)
       thor
       webrick
-    pact-support (0.5.8)
+    pact-support (0.5.9)
       awesome_print (~> 1.1)
       find_a_port (~> 1.0.1)
       json
@@ -24,33 +50,51 @@ GEM
       rspec (>= 2.14)
       term-ansicolor (~> 1.0)
       thor
-    rack (1.6.4)
+    plist (3.2.0)
+    rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     randexp (0.1.7)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.4)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rouge (1.11.1)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.3)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rubyzip (1.1.7)
+    scan (0.13.0)
+      fastlane_core (>= 0.52.0, < 1.0.0)
+      slack-notifier (~> 1.3)
+      terminal-table
+      xcpretty (>= 0.2.1)
+      xcpretty-travis-formatter (>= 0.0.3)
+    security (0.1.3)
+    slack-notifier (1.5.1)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
+    terminal-table (1.4.5)
     thor (0.19.1)
-    tins (1.10.2)
+    tins (1.12.0)
     webrick (1.3.1)
-    xcpretty (0.1.7)
+    xcpretty (0.2.2)
+      rouge (~> 1.8)
+    xcpretty-travis-formatter (0.0.4)
+      xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  pact-mock_service (~> 0.9.0)
-  xcpretty
+  pact-mock_service (~> 0.10.2)
+  scan (~> 0.13.0)
+
+BUNDLED WITH
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Note: see [Upgrading][upgrading] for notes on upgrading from 0.2 to 0.3
 - See the [PactSwiftExample](https://github.com/andrewspinks/PactSwiftExample) for an example project using the library with Carthage.
 
 #### Using CocoaPods
-
 - See the [PactObjectiveCExample](https://github.com/andrewspinks/PactObjectiveCExample) for an example project using the library with CocoaPods.
 
 ## Writing Pact Tests
@@ -119,7 +118,8 @@ And the generated pacts, here:
 
   See [Verifying pacts](http://docs.pact.io/documentation/verifying_pacts.html) for more information.
 
-For an end to end example with a ruby back end service, have a look at the [KatKit example](https://github.com/andrewspinks/pact-mobile-preso)
+For an end to end example with a ruby back end service, have a look at the [KatKit example](https://github.com/andrewspinks/pact-mobile-preso).
+[Here](https://medium.com/@rajatvig/ios-docker-and-consumer-driven-contract-testing-with-pact-d99b6bf4b09e#.ozcbbktzk) is an article using a dockerized nodejs service which uses provider states.
 
 # More reading
 * The Pact website [Pact](http://pact.io)

--- a/Scanfile
+++ b/Scanfile
@@ -1,0 +1,4 @@
+clean true
+code_coverage false
+skip_slack true
+device "iPhone 7"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-xcodebuild -workspace PactConsumerSwift.xcworkspace -scheme PactConsumerSwift test -destination 'platform=iOS Simulator,OS=10.0,name=iPhone 6' -sdk iphonesimulator | xcpretty -c
+scan


### PR DESCRIPTION
I created a [post](https://medium.com/@rajatvig/ios-docker-and-consumer-driven-contract-testing-with-pact-d99b6bf4b09e#.ozcbbktzk) on how to use it and was planning to update it to use Swift 3.
Is there a release timeline around this branch?
