### PR TITLE
Fixed issue preventing the pact writing

### DIFF
--- a/Sources/PactVerificationService.swift
+++ b/Sources/PactVerificationService.swift
@@ -93,7 +93,8 @@ open class PactVerificationService {
     let promise = Promise<String, NSError>()
     Alamofire.request(Router.verify())
     .validate()
-
+    .responseString { response in self.requestHandler(promise)(response) }
+    
     return promise.future
   }
 


### PR DESCRIPTION
In the current version, the `verifyInteractions` method in the `PactVerificationService` returns a promise but it never resolves it. As a result, the pacts do NEVER get written.