### PR TITLE
Wait on verify to complete before allowing tests to continue

### DIFF
--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -69,12 +69,15 @@ open class MockService: NSObject {
       }
     }
 
-    self.pactVerificationService.verify(provider: self.provider,
-                                        consumer: self.consumer).onSuccess { _ in
-    }.onFailure { error in
-      self.failWithLocation("Verification error (check build log for mismatches): \(error.localizedDescription)",
-        file: file,
-        line: line)
+    waitUntilWithLocation(timeout: timeout, file: file, line: line) { done in
+        self.pactVerificationService.verify(provider: self.provider,
+                                            consumer: self.consumer).onSuccess { _ in
+                                                done()
+        }.onFailure { error in
+          self.failWithLocation("Verification error (check build log for mismatches): \(error.localizedDescription)",
+            file: file,
+            line: line)
+        }
     }
   }
 


### PR DESCRIPTION
While using `pact-consumer-swift` we have seen flakey results in our pact tests.  Upon investigation, it appears that:

The call to pactVerificationService.verify asynchronously communicates with the server, and the run function will return before it's done. If a subsequent spec comes along and clears the interactions from the server, it will cause a race.