### PR TITLE
Update dependencies

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "Alamofire/Alamofire" ~> 4.7
 github "Thomvis/BrightFutures" ~> 7.0
-github "Quick/Nimble" ~> 7.3
-github "Quick/Quick" ~> 1.3
+github "Quick/Nimble" ~> 8.0
+github "Quick/Quick" ~> 2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Alamofire/Alamofire" "4.8.1"
-github "Quick/Nimble" "v7.3.2"
-github "Quick/Quick" "v1.3.2"
+github "Quick/Nimble" "v8.0.1"
+github "Quick/Quick" "v2.0.0"
 github "Thomvis/BrightFutures" "7.0.0"
 github "antitypical/Result" "4.1.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "b8995447518fd57af14c88a47f27434a16f60403",
-          "version": "4.5.1"
+          "revision": "d82c7943d80785834da4693b92133012626c060b",
+          "version": "4.8.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "39b67002306fda9de4c9fd1290a6295f97edd09e",
-          "version": "7.0.1"
+          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
+          "version": "8.0.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "e4fa1e85c0305ba4e0866f25812d3fa398f3a048",
-          "version": "1.1.0"
+          "revision": "0b4ed6c706dd0cce923b5019a605a9bcc6b1b600",
+          "version": "2.0.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "c8446185238659a2b27c0261f64ff1254291d07d",
-          "version": "3.2.3"
+          "revision": "7477584259bfce2560a19e06ad9f71db441fff11",
+          "version": "3.2.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/Alamofire/Alamofire.git", from: "4.5.1"),
-    .package(url: "https://github.com/Quick/Quick.git", from: "1.1.0"),
-    .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.1"),
+    .package(url: "https://github.com/Quick/Quick.git", from: "2.0.0"),
+    .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
     .package(url: "https://github.com/Thomvis/BrightFutures.git", from: "5.2.0")
   ],
   targets: [

--- a/PactConsumerSwift.podspec
+++ b/PactConsumerSwift.podspec
@@ -28,6 +28,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.7'
   s.dependency 'BrightFutures', '~> 7.0'
-  s.dependency 'Nimble', '~> 7.3'
-  s.dependency 'Quick', '~> 1.3'
+  s.dependency 'Nimble', '~> 8.0'
+  s.dependency 'Quick', '~> 2.0'
 end


### PR DESCRIPTION
This PR updates the dependencies, so that the framework can be built with Xcode 10.2.
The main issues were `Quick` and `Nimble`, as their pinned version was not buildable with Xcode 10.2. 