### PR TITLE
Remove quick dependency from requirements. It is only used for intern…

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
 github "Thomvis/BrightFutures" ~> 7.0
 github "Quick/Nimble" ~> 8.0
-github "Quick/Quick" ~> 2.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,1 @@
+github "Quick/Quick" ~> 2.0

--- a/Package.resolved
+++ b/Package.resolved
@@ -20,15 +20,6 @@
         }
       },
       {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick.git",
-        "state": {
-          "branch": null,
-          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
-          "version": "2.1.0"
-        }
-      },
-      {
         "package": "Result",
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
     .library(name: "PactConsumerSwift", targets: ["PactConsumerSwift"])
   ],
   dependencies: [
-    .package(url: "https://github.com/Quick/Quick.git", from: "2.1.0"),
     .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
     .package(url: "https://github.com/antitypical/Result.git", from: "5.0.0"),
     .package(url: "https://github.com/Thomvis/BrightFutures.git", from: "8.0.0")
@@ -21,10 +20,6 @@ let package = Package(
       name: "PactConsumerSwift",
       dependencies: ["BrightFutures", "Nimble", "Result"],
       path: "./Sources"
-    ),
-    .testTarget(
-      name: "PactConsumerSwiftTests",
-      dependencies: ["PactConsumerSwift", "BrightFutures", "Nimble", "Quick", "Result"]
     )
   ]
 )

--- a/PactConsumerSwift.podspec
+++ b/PactConsumerSwift.podspec
@@ -28,5 +28,4 @@ Pod::Spec.new do |s|
 
   s.dependency 'BrightFutures', '~> 7.0'
   s.dependency 'Nimble', '~> 8.0'
-  s.dependency 'Quick', '~> 2.0'
 end

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,10 +19,4 @@ xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" 
 
 # SwiftPM
 echo "#### Testing DEBUG configuration for SwiftPM compatibility ####"
-mkdir -p "${SRCROOT}/tmp"
-pact-mock-service start --pact-specification-version 2.0.0 --log "${SRCROOT}/tmp/pact.log" --pact-dir "${SRCROOT}/tmp/pacts" -p 1234
-swift build && swift test
-
-echo "#### Testing RELEASE configuration for SwiftPM compatibility ####"
-swift build -c release && swift test
-pact-mock-service stop
+swift build


### PR DESCRIPTION
This was added into normal dependencies by mistake somewhere along the way, but is only needed internally for testing. 