### PR TITLE
Fixes bitcode related issue when used from CocoaPods.

### DIFF
--- a/PactConsumerSwift.podspec
+++ b/PactConsumerSwift.podspec
@@ -26,6 +26,10 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.frameworks   = 'XCTest'
 
+  s.pod_target_xcconfig = {
+    'ENABLE_BITCODE' => 'NO'
+  }
+
   s.dependency 'BrightFutures', '~> 7.0'
   s.dependency 'Nimble', '~> 8.0'
 end


### PR DESCRIPTION
Closes #43

This change only has an effect when a project uses the PactConsumerSwift as a CocoaPod.  Also only has an effect when the project's tests (not the PactConsumerSwift project, but the project that uses the PactConsumerSwift pod) are run on an actual device.

Tested locally on both simulator and actual iOS devices and this change is all that's needed.

The CocoaPod will need to be released with an updated version number for this update to really take effect for everyone.