### PR TITLE
Cleanup access controls on classes to hide internal concepts.

### DIFF
--- a/Sources/Interaction.swift
+++ b/Sources/Interaction.swift
@@ -6,11 +6,11 @@ public enum PactHTTPMethod: Int {
 }
 
 @objc
-open class Interaction: NSObject {
-  open var providerState: String?
-  open var testDescription: String = ""
-  open var request: [String: Any] = [:]
-  open var response: [String: Any] = [:]
+public class Interaction: NSObject {
+  private var providerState: String?
+  private var testDescription: String = ""
+  private var request: [String: Any] = [:]
+  private var response: [String: Any] = [:]
 
   ///
   /// Define the providers state
@@ -23,7 +23,7 @@ open class Interaction: NSObject {
   /// - Returns: An `Interaction` object
   ///
   @discardableResult
-  open func given(_ providerState: String) -> Interaction {
+  public func given(_ providerState: String) -> Interaction {
     self.providerState = providerState
     return self
   }
@@ -41,7 +41,7 @@ open class Interaction: NSObject {
   ///
   @objc
   @discardableResult
-  open func uponReceiving(_ testDescription: String) -> Interaction {
+  public func uponReceiving(_ testDescription: String) -> Interaction {
     self.testDescription = testDescription
     return self
   }
@@ -64,7 +64,7 @@ open class Interaction: NSObject {
   ///
   @objc(withRequestHTTPMethod: path: query: headers: body:)
   @discardableResult
-  open func withRequest(method: PactHTTPMethod,
+  public func withRequest(method: PactHTTPMethod,
                         path: Any,
                         query: Any? = nil,
                         headers: [String: Any]? = nil,
@@ -101,7 +101,7 @@ open class Interaction: NSObject {
   ///
   @objc(willRespondWithHTTPStatus: headers: body:)
   @discardableResult
-  open func willRespondWith(status: Int,
+  public func willRespondWith(status: Int,
                             headers: [String: Any]? = nil,
                             body: Any? = nil) -> Interaction {
     response = ["status": status]
@@ -116,7 +116,7 @@ open class Interaction: NSObject {
 
   ///
   @objc
-  open func payload() -> [String: Any] {
+  func payload() -> [String: Any] {
     var payload: [String: Any] = ["description": testDescription,
                                   "request": request,
                                   "response": response ]
@@ -128,7 +128,7 @@ open class Interaction: NSObject {
 
   // MARK: - Private
 
-  fileprivate func httpMethod(_ method: PactHTTPMethod) -> String {
+  private func httpMethod(_ method: PactHTTPMethod) -> String {
     switch method {
     case .GET:
       return "get"

--- a/Sources/Matcher.swift
+++ b/Sources/Matcher.swift
@@ -3,7 +3,8 @@ import Foundation
 @objc
 open class Matcher: NSObject {
 
-  @objc open class func term(matcher: String, generate: String) -> [String: Any] {
+  @objc
+  public class func term(matcher: String, generate: String) -> [String: Any] {
     return [ "json_class": "Pact::Term",
       "data": [
         "generate": generate,
@@ -15,7 +16,7 @@ open class Matcher: NSObject {
   }
 
   @objc
-  open class func somethingLike(_ value: Any) -> [String: Any] {
+  public class func somethingLike(_ value: Any) -> [String: Any] {
     return [
       "json_class": "Pact::SomethingLike",
       "contents": value
@@ -23,7 +24,7 @@ open class Matcher: NSObject {
   }
 
   @objc
-  open class func eachLike(_ value: Any, min: Int = 1) -> [String: Any] {
+  public class func eachLike(_ value: Any, min: Int = 1) -> [String: Any] {
     return [
       "json_class": "Pact::ArrayLike",
       "contents": value,

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -5,14 +5,14 @@ import Nimble
 
 @objc
 open class MockService: NSObject {
-  fileprivate let provider: String
-  fileprivate let consumer: String
-  fileprivate let pactVerificationService: PactVerificationService
-  fileprivate var interactions: [Interaction] = []
+  private let provider: String
+  private let consumer: String
+  private let pactVerificationService: PactVerificationService
+  private var interactions: [Interaction] = []
 
   /// The baseUrl of Pact Mock Service
   @objc
-  open var baseUrl: String {
+  public var baseUrl: String {
     return pactVerificationService.baseUrl
   }
 
@@ -27,7 +27,7 @@ open class MockService: NSObject {
     provider: String,
     consumer: String,
     pactVerificationService: PactVerificationService
-    ) {
+  ) {
     self.provider = provider
     self.consumer = consumer
     self.pactVerificationService = pactVerificationService
@@ -59,7 +59,7 @@ open class MockService: NSObject {
   /// - Returns: An `Interaction` object
   ///
   @objc
-  open func given(_ providerState: String) -> Interaction {
+  public func given(_ providerState: String) -> Interaction {
     let interaction = Interaction().given(providerState)
     interactions.append(interaction)
     return interaction
@@ -76,7 +76,7 @@ open class MockService: NSObject {
   /// - Returns: An `Interaction` object
   ///
   @objc(uponReceiving:)
-  open func uponReceiving(_ description: String) -> Interaction {
+  public func uponReceiving(_ description: String) -> Interaction {
     let interaction = Interaction().uponReceiving(description)
     interactions.append(interaction)
     return interaction
@@ -98,7 +98,7 @@ open class MockService: NSObject {
   /// - Parameter testFunction: The function making the network request you are testing
   ///
   @objc(run:)
-  open func objcRun(_ testFunction: @escaping (_ testComplete: () -> Void) -> Void) {
+  public func objcRun(_ testFunction: @escaping (_ testComplete: () -> Void) -> Void) {
     self.run(nil, line: nil, timeout: 30, testFunction: testFunction)
   }
 
@@ -119,8 +119,10 @@ open class MockService: NSObject {
   /// - Parameter timeout: Time to wait for the `testComplete()` else it fails the test
   ///
   @objc(run: withTimeout:)
-  open func objcRun(_ testFunction: @escaping (_ testComplete: () -> Void) -> Void,
-                    timeout: TimeInterval) {
+  public func objcRun(
+    _ testFunction: @escaping (_ testComplete: () -> Void) -> Void,
+    timeout: TimeInterval
+  ) {
     self.run(nil, line: nil, timeout: timeout, testFunction: testFunction)
   }
 
@@ -139,7 +141,7 @@ open class MockService: NSObject {
   /// - Parameter timeout: Number of seconds how long to wait for `testComplete()` before marking the test as failed.
   /// - Parameter testFunction: The function making the network request you are testing
   ///
-  open func run(
+  public func run(
     _ file: FileString? = #file,
     line: UInt? = #line,
     timeout: TimeInterval = 30,
@@ -169,7 +171,7 @@ open class MockService: NSObject {
 
   // MARK: - Helper methods
 
-  func failWithLocation(
+  private func failWithLocation(
     _ message: String,
     file: FileString?,
     line: UInt?
@@ -181,7 +183,7 @@ open class MockService: NSObject {
     }
   }
 
-  public func waitUntilWithLocation(
+  private func waitUntilWithLocation(
     timeout: TimeInterval,
     file: FileString?,
     line: UInt?,

--- a/Sources/PactVerificationService.swift
+++ b/Sources/PactVerificationService.swift
@@ -3,11 +3,11 @@ import BrightFutures
 
 open class PactVerificationService {
 
-  open var baseUrl: String {
+  var baseUrl: String {
     return "\(PactMockServiceAPI.url):\(PactMockServiceAPI.port)"
   }
 
-  var networkManager: NetworkManager!
+  private var networkManager: NetworkManager!
 
   ///
   /// Networking service that talks to your Pact-Mock-Service (eg: pact-ruby-standalone)
@@ -21,7 +21,7 @@ open class PactVerificationService {
     port: Int = 1234,
     networkLogging: Bool = false,
     networkManager: NetworkManager? = nil
-    ) {
+  ) {
     PactMockServiceAPI.url = url
     PactMockServiceAPI.port = port
     PactMockServiceAPI.enableNetworkLogging = networkLogging
@@ -32,7 +32,7 @@ open class PactVerificationService {
   ///
   /// Calls Pact-Mock-Service and sets the interactions between your Consumer and Provider
   ///
-  func setup(_ interactions: [Interaction]) -> Future<String, NSError> {
+  public func setup(_ interactions: [Interaction]) -> Future<String, NSError> {
     let promise = Promise<String, NSError>()
 
     self.clean()
@@ -49,7 +49,7 @@ open class PactVerificationService {
   ///
   /// Verifies the interactions between your Consumer and Provider
   ///
-  func verify(provider: String, consumer: String) -> Future<String, NSError> {
+  public func verify(provider: String, consumer: String) -> Future<String, NSError> {
     let promise = Promise<String, NSError>()
 
     self.verifyInteractions()
@@ -65,7 +65,7 @@ open class PactVerificationService {
 
   // MARK: - Fileprivate
 
-  fileprivate func clean() -> Future<String, NSError> {
+  private func clean() -> Future<String, NSError> {
     let promise = Promise<String, NSError>()
 
     networkManager
@@ -76,7 +76,7 @@ open class PactVerificationService {
     return promise.future
   }
 
-  fileprivate func setupInteractions (_ interactions: [Interaction]) -> Future<String, NSError> {
+  private func setupInteractions (_ interactions: [Interaction]) -> Future<String, NSError> {
     let promise = Promise<String, NSError>()
 
     let parameters: [String: Any] = ["interactions": interactions.map({ $0.payload() }),
@@ -90,7 +90,7 @@ open class PactVerificationService {
     return promise.future
   }
 
-  fileprivate func verifyInteractions() -> Future<String, NSError> {
+  private func verifyInteractions() -> Future<String, NSError> {
     let promise = Promise<String, NSError>()
 
     networkManager
@@ -101,7 +101,7 @@ open class PactVerificationService {
     return promise.future
   }
 
-  fileprivate func write(provider: String, consumer: String) -> Future<String, NSError> {
+  private func write(provider: String, consumer: String) -> Future<String, NSError> {
     let promise = Promise<String, NSError>()
 
     let parameters: [String: [String: String]] = ["consumer": [ "name": consumer ],
@@ -117,7 +117,7 @@ open class PactVerificationService {
 
   // MARK: - Helpers
 
-  fileprivate func failWithError(
+  private func failWithError(
     _ error: String,
     code: Int = 0,
     domain: String = "",
@@ -127,7 +127,7 @@ open class PactVerificationService {
     return NSError(domain: domain, code: code, userInfo: userInfo)
   }
 
-  fileprivate func handleResponse(_ promise: Promise<String, NSError>) -> NetworkCallResultCompletion {
+  private func handleResponse(_ promise: Promise<String, NSError>) -> NetworkCallResultCompletion {
     return { result in
       switch result {
       case .success(let resultString):

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -24,7 +24,7 @@ class Router<EndPoint: EndPointType>: NetworkRouter {
 
   // MARK: -
 
-  fileprivate func buildRequest(from route: EndPoint) throws -> URLRequest {
+  private func buildRequest(from route: EndPoint) throws -> URLRequest {
 
     var request = URLRequest(url: route.baseURL.appendingPathComponent(route.path),
                              cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
@@ -48,7 +48,7 @@ class Router<EndPoint: EndPointType>: NetworkRouter {
     }
   }
 
-  fileprivate func configureParameters(
+  private func configureParameters(
     bodyParameters: Parameters?,
     urlParameters: Parameters?,
     request: inout URLRequest
@@ -65,7 +65,7 @@ class Router<EndPoint: EndPointType>: NetworkRouter {
     }
   }
 
-  fileprivate func addHeaders(_ headers: HTTPHeaders?, request: inout URLRequest) {
+  private func addHeaders(_ headers: HTTPHeaders?, request: inout URLRequest) {
     guard let headers = headers else { return }
     _ = headers.map { request.setValue($1, forHTTPHeaderField: $0) }
   }

--- a/Tests/InteractionSpec.swift
+++ b/Tests/InteractionSpec.swift
@@ -1,18 +1,11 @@
 import Quick
 import Nimble
-import PactConsumerSwift
+@testable import PactConsumerSwift
 
 class InteractionSpec: QuickSpec {
   override func spec() {
     var interaction: Interaction?
     beforeEach { interaction = Interaction() }
-
-    describe("interaction state setup") {
-      it("it initialises the provider state") {
-        expect(interaction?.given("some state").providerState).to(equal("some state"))
-      }
-      
-    }
 
     describe("json payload"){
       context("pact state") {


### PR DESCRIPTION
Most of these accessors (the open ones anyway) were originally added by an xcode upgrade after swift finally supported defining them. 