### PR TITLE
Add escaping modifier to allow for testComplete function to be called…

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
-          "version": "8.0.1"
+          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
+          "version": "8.0.2"
         }
       },
       {

--- a/PactConsumerObjCTests/PactObjectiveCTests.m
+++ b/PactConsumerObjCTests/PactObjectiveCTests.m
@@ -137,4 +137,29 @@
   }];
 }
 
+- (void)testAsyncCall {
+    typedef void (^CompleteBlock)(void);
+    
+    [[[self.animalMockService uponReceiving:@"an async request"]
+      withRequestHTTPMethod:PactHTTPMethodGET
+      path:@"/path"
+      query:nil
+      headers:nil
+      body: nil]
+     willRespondWithHTTPStatus:200
+     headers:@{@"Content-Type": @"application/json"}
+     body: @{}];
+    
+    [self.animalMockService run:^(CompleteBlock testComplete) {
+        NSString *dataUrl = @"http://localhost:1234/path";
+        NSURL *url = [NSURL URLWithString:dataUrl];
+        NSURLSessionDataTask *asyncTask = [[NSURLSession sharedSession]
+                                           dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                               testComplete();
+                                           }];
+        [asyncTask resume];
+    }
+     ];
+}
+
 @end

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -102,7 +102,7 @@ open class MockService: NSObject {
   /// - Parameter testFunction: The function making the network request you are testing
   ///
   @objc(run:)
-  public func objcRun(_ testFunction: @escaping (_ testComplete: () -> Void) -> Void) {
+  public func objcRun(_ testFunction: @escaping (_ testComplete:@escaping () -> Void) -> Void) {
     self.run(nil, line: nil, timeout: 30, testFunction: testFunction)
   }
 

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -102,7 +102,7 @@ open class MockService: NSObject {
   /// - Parameter testFunction: The function making the network request you are testing
   ///
   @objc(run:)
-  public func objcRun(_ testFunction: @escaping (_ testComplete:@escaping () -> Void) -> Void) {
+  public func objcRun(_ testFunction: @escaping (_ testComplete: @escaping () -> Void) -> Void) {
     self.run(nil, line: nil, timeout: 30, testFunction: testFunction)
   }
 
@@ -124,7 +124,7 @@ open class MockService: NSObject {
   ///
   @objc(run: withTimeout:)
   public func objcRun(
-    _ testFunction: @escaping (_ testComplete:@escaping () -> Void) -> Void,
+    _ testFunction: @escaping (_ testComplete: @escaping () -> Void) -> Void,
     timeout: TimeInterval
   ) {
     self.run(nil, line: nil, timeout: timeout, testFunction: testFunction)

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -124,7 +124,7 @@ open class MockService: NSObject {
   ///
   @objc(run: withTimeout:)
   public func objcRun(
-    _ testFunction: @escaping (_ testComplete: () -> Void) -> Void,
+    _ testFunction: @escaping (_ testComplete:@escaping () -> Void) -> Void,
     timeout: TimeInterval
   ) {
     self.run(nil, line: nil, timeout: timeout, testFunction: testFunction)


### PR DESCRIPTION
… in an async block.  I've also created a simple Pact test that reproduces the issue: https://gist.github.com/marturi/28b11068ec1f45288c7c954e505c041e