### PR TITLE
Use pact with self signed ssl certificates

### DIFF
--- a/Sources/PactVerificationService.swift
+++ b/Sources/PactVerificationService.swift
@@ -4,10 +4,8 @@ import BrightFutures
 open class PactVerificationService: NSObject {
   public let url: String
   public let port: Int
-  /// True if insecure certificates are allowed, otherwise false.
-  /// Default value is false.
-  /// Set this to true when you are using self signed SSL certifiates, or any invalid SSL certificates.
-  public var allowInsecureCertificates: Bool = false
+  public let allowInsecureCertificates: Bool
+  
   open var baseUrl: String {
     return "\(url):\(port)"
   }
@@ -74,9 +72,11 @@ open class PactVerificationService: NSObject {
     }
   }
 
-  public init(url: String = "http://localhost", port: Int = 1234) {
+  public init(url: String = "http://localhost", port: Int = 1234, allowInsecureCertificates: Bool = false) {
     self.url = url
     self.port = port
+    self.allowInsecureCertificates = allowInsecureCertificates
+    
     super.init()
     Router.baseURLString = baseUrl
   }
@@ -201,6 +201,6 @@ extension PactVerificationService: URLSessionDelegate {
     }
 
     let proposedCredential = URLCredential(trust: serverTrust)
-    completionHandler(URLSession.AuthChallengeDisposition.useCredential, proposedCredential)
+    completionHandler(.useCredential, proposedCredential)
   }
 }

--- a/Sources/PactVerificationService.swift
+++ b/Sources/PactVerificationService.swift
@@ -6,7 +6,7 @@ open class PactVerificationService: NSObject {
   public let port: Int
   /// True if insecure certificates are allowed, otherwise false.
   /// Default value is false.
-  /// Set this to true this when you are using self signed SSL certifiates, or any invalid SSL certificates.
+  /// Set this to true when you are using self signed SSL certifiates, or any invalid SSL certificates.
   public var allowInsecureCertificates: Bool = false
   open var baseUrl: String {
     return "\(url):\(port)"
@@ -193,7 +193,6 @@ extension PactVerificationService: URLSessionDelegate {
   public func urlSession(_ session: URLSession,
                          didReceive challenge: URLAuthenticationChallenge,
                          completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-
     guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
         allowInsecureCertificates,
         let serverTrust = challenge.protectionSpace.serverTrust else {

--- a/Sources/PactVerificationService.swift
+++ b/Sources/PactVerificationService.swift
@@ -5,7 +5,7 @@ open class PactVerificationService: NSObject {
   public let url: String
   public let port: Int
   public let allowInsecureCertificates: Bool
-  
+
   open var baseUrl: String {
     return "\(url):\(port)"
   }
@@ -76,7 +76,7 @@ open class PactVerificationService: NSObject {
     self.url = url
     self.port = port
     self.allowInsecureCertificates = allowInsecureCertificates
-    
+
     super.init()
     Router.baseURLString = baseUrl
   }


### PR DESCRIPTION
This PR adds the functionality to allow self signed certificates and is a solution to issue https://github.com/DiUS/pact-consumer-swift/issues/73.
pact-mock-service has a `--ssl` option parameter to create a self signed SSL certificate and will change the base URL from `http://localhost` to `https:localhost`.

In order to test this, the `start_server.sh` script needs to be modified to include the `--ssl` option.
PactVerificationService needs to be initialized with the new baseUrl and the option needs to be changed to true.

```
let verificationService = PactVerificationService(url: "https://localhost", port: 1234)
verificationService.allowInsecureCertificates = true
mockService = MockService(
  provider: "ABC Service", 
  consumer: "unit tests",
  pactVerificationService: verificationService,
  errorReporter: errorCapturer!
)
```

I haven't changed the start_service script to use `--ssl`, because that will affect all the tests, but I can do that as well, so this code is covered by tests as well.
I tried to implement the less intrusive solution.
I don't think anybody needs the actual authentication challenge function exposed, but they can propose the change when it will be necessary.