### PR TITLE
Bump up BrightFutures version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Thomvis/BrightFutures" ~> 7.0
+github "Thomvis/BrightFutures" ~> 8.0
 github "Quick/Nimble" ~> 8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "8.0.0"
 github "Quick/Nimble" "v8.0.2"
 github "Quick/Quick" "v2.1.0"
-github "Thomvis/BrightFutures" "7.0.1"
-github "antitypical/Result" "4.1.0"
+github "Thomvis/BrightFutures" "8.0.1"

--- a/PactConsumerSwift.podspec
+++ b/PactConsumerSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "PactConsumerSwift"
   s.module_name  = "PactConsumerSwift"
-  s.version      = "0.6.1"
+  s.version      = "0.6.2"
   s.summary      = "A Swift / ObjeciveC DSL for creating pacts."
   s.license      = { :type => 'MIT' }
 
@@ -30,6 +30,6 @@ Pod::Spec.new do |s|
     'ENABLE_BITCODE' => 'NO'
   }
 
-  s.dependency 'BrightFutures', '~> 7.0'
+  s.dependency 'BrightFutures', '~> 8.0'
   s.dependency 'Nimble', '~> 8.0'
 end

--- a/PactConsumerSwift.podspec
+++ b/PactConsumerSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "PactConsumerSwift"
   s.module_name  = "PactConsumerSwift"
-  s.version      = "0.6.2"
+  s.version      = "0.6.1"
   s.summary      = "A Swift / ObjeciveC DSL for creating pacts."
   s.license      = { :type => 'MIT' }
 

--- a/PactConsumerSwift.xcodeproj/project.pbxproj
+++ b/PactConsumerSwift.xcodeproj/project.pbxproj
@@ -704,7 +704,6 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/BrightFutures.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Result.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Quick.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/OHHTTPStubs.framework",
 			);
@@ -724,7 +723,6 @@
 				"$(SRCROOT)/Carthage/Build/Mac/BrightFutures.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/Nimble.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/Quick.framework",
-				"$(SRCROOT)/Carthage/Build/Mac/Result.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/OHHTTPStubs.framework",
 			);
 			name = "Copy Carthage Frameworks";
@@ -743,7 +741,6 @@
 				"$(SRCROOT)/Carthage/Build/tvOS/BrightFutures.framework",
 				"$(SRCROOT)/Carthage/Build/tvOS/Nimble.framework",
 				"$(SRCROOT)/Carthage/Build/tvOS/Quick.framework",
-				"$(SRCROOT)/Carthage/Build/tvOS/Result.framework",
 				"$(SRCROOT)/Carthage/Build/tvOS/OHHTTPStubs.framework",
 			);
 			name = "Copy Carthage Frameworks";

--- a/PactConsumerSwift.xcodeproj/project.pbxproj
+++ b/PactConsumerSwift.xcodeproj/project.pbxproj
@@ -66,10 +66,8 @@
 		ADC03E271F74C64F003FCA6A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E241F74C64E003FCA6A /* Nimble.framework */; };
 		ADC03E2A1F74C68E003FCA6A /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E231F74C64E003FCA6A /* BrightFutures.framework */; };
 		ADC03E2B1F74C68E003FCA6A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E241F74C64E003FCA6A /* Nimble.framework */; };
-		ADC03E2E1F74C68E003FCA6A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E2C1F74C68E003FCA6A /* Result.framework */; };
 		ADC03E2F1F74C68E003FCA6A /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E2D1F74C68E003FCA6A /* Quick.framework */; };
 		ADC03E351F74C8A5003FCA6A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E301F74C8A5003FCA6A /* Nimble.framework */; };
-		ADC03E361F74C8A5003FCA6A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E311F74C8A5003FCA6A /* Result.framework */; };
 		ADC03E371F74C8A5003FCA6A /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E321F74C8A5003FCA6A /* BrightFutures.framework */; };
 		ADC03E391F74C8A5003FCA6A /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E341F74C8A5003FCA6A /* Quick.framework */; };
 		ADC03E3B1F74C8EE003FCA6A /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E321F74C8A5003FCA6A /* BrightFutures.framework */; };
@@ -78,7 +76,6 @@
 		ADC03E3E1F74C920003FCA6A /* MatcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD17A6501F74BAA900219F39 /* MatcherSpec.swift */; };
 		ADC03E3F1F74C987003FCA6A /* OCAnimalServiceClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AD17A6541F74BAC700219F39 /* OCAnimalServiceClient.m */; };
 		ADC03E401F74C989003FCA6A /* PactObjectiveCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AD17A6531F74BAC700219F39 /* PactObjectiveCTests.m */; };
-		ADF13D671F7B7FAE009532F6 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E341F74C8A5003FCA6A /* Quick.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -189,7 +186,6 @@
 				ADC03E2A1F74C68E003FCA6A /* BrightFutures.framework in Frameworks */,
 				ADC03E2B1F74C68E003FCA6A /* Nimble.framework in Frameworks */,
 				ADC03E2F1F74C68E003FCA6A /* Quick.framework in Frameworks */,
-				ADC03E2E1F74C68E003FCA6A /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -197,7 +193,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ADF13D671F7B7FAE009532F6 /* Quick.framework in Frameworks */,
 				ADC03E3B1F74C8EE003FCA6A /* BrightFutures.framework in Frameworks */,
 				ADC03E3C1F74C8EE003FCA6A /* Nimble.framework in Frameworks */,
 			);
@@ -212,7 +207,6 @@
 				ADC03E371F74C8A5003FCA6A /* BrightFutures.framework in Frameworks */,
 				ADC03E351F74C8A5003FCA6A /* Nimble.framework in Frameworks */,
 				ADC03E391F74C8A5003FCA6A /* Quick.framework in Frameworks */,
-				ADC03E361F74C8A5003FCA6A /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -1,6 +1,5 @@
 import Foundation
 import BrightFutures
-import Result
 import Nimble
 
 @objc

--- a/Tests/InteractionSpec.swift
+++ b/Tests/InteractionSpec.swift
@@ -10,7 +10,7 @@ class InteractionSpec: QuickSpec {
     describe("json payload"){
       context("pact state") {
         it("includes provider state in the payload") {
-          var payload = interaction!.given("state of awesomeness").uponReceiving("an important request is received").payload()
+          let payload = interaction!.given("state of awesomeness").uponReceiving("an important request is received").payload()
 
           expect(payload["providerState"] as! String?) == "state of awesomeness"
           expect(payload["description"] as! String?) == "an important request is received"
@@ -19,7 +19,7 @@ class InteractionSpec: QuickSpec {
 
       context("no provider state") {
         it("doesn not include provider state when not included") {
-          var payload = interaction!.uponReceiving("an important request is received").payload()
+          let payload = interaction!.uponReceiving("an important request is received").payload()
 
           expect(payload["providerState"]).to(beNil())
         }
@@ -32,9 +32,9 @@ class InteractionSpec: QuickSpec {
         let body = "blah"
 
         it("returns expected request with specific headers and body") {
-          var payload = interaction!.withRequest(method: method, path: path, headers: headers, body: body).payload()
+          let payload = interaction!.withRequest(method: method, path: path, headers: headers, body: body).payload()
 
-          var request = payload["request"] as! [String: AnyObject]
+          let request = payload["request"] as! [String: AnyObject]
           expect(request["path"] as! String?) == path
           expect(request["method"] as! String?).to(equal("put"))
           expect(request["headers"] as! [String: String]?).to(equal(headers))
@@ -42,9 +42,9 @@ class InteractionSpec: QuickSpec {
         }
 
         it("returns expected request without body and headers") {
-          var payload = interaction!.withRequest(method:method, path: path).payload()
+          let payload = interaction!.withRequest(method:method, path: path).payload()
 
-          var request = payload["request"] as! [String: AnyObject]
+          let request = payload["request"] as! [String: AnyObject]
           expect(request["path"] as! String?) == path
           expect(request["method"] as! String?).to(equal("put"))
           expect(request["headers"] as! [String: String]?).to(beNil())
@@ -58,9 +58,9 @@ class InteractionSpec: QuickSpec {
         let body = "body"
 
         it("returns expected response with specific headers and body") {
-          var payload = interaction!.willRespondWith(status: statusCode, headers: headers, body: body).payload()
+          let payload = interaction!.willRespondWith(status: statusCode, headers: headers, body: body).payload()
 
-          var request = payload["response"] as! [String: AnyObject]
+          let request = payload["response"] as! [String: AnyObject]
           expect(request["status"] as! Int?) == statusCode
           expect(request["headers"] as! [String: String]?).to(equal(headers))
           expect(request["body"] as! String?).to(equal(body))

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@ set -e
 
 if [[ -z "${PROJECT_NAME}" ]]; then
   PROJECT_NAME="PactConsumerSwift.xcodeproj";
-  DESTINATION="OS=12.4,name=iPhone Xs";
+  DESTINATION="OS=13.0,name=iPhone Xʀ";
   SCHEME="PactConsumerSwift iOS";
   CARTHAGE_PLATFORM="iOS";
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@ set -e
 
 if [[ -z "${PROJECT_NAME}" ]]; then
   PROJECT_NAME="PactConsumerSwift.xcodeproj";
-  DESTINATION="OS=12.2,name=iPhone Xs";
+  DESTINATION="OS=12.4,name=iPhone Xs";
   SCHEME="PactConsumerSwift iOS";
   CARTHAGE_PLATFORM="iOS";
 fi


### PR DESCRIPTION
To support Swift 5 in this project, dependencies used in the project need to be updated as well.

The proposed changes:
- Update the `Cartfile`, `Cocoapods` files to update BrightFutures dependency to `8.0`,
- Remove references to `Result.framework` that has been removed from the project in previous releases
- Fix code in tests where `let` should have been used for a non-mutable variables.

This will resolve #75 