### PR TITLE
style: add convenience init to MockService

### DIFF
--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -22,6 +22,7 @@ open class MockService: NSObject {
   /// - parameter provider: Name of your provider (eg: Calculator API)
   /// - parameter consumer: Name of your consumer (eg: Calculator.app)
   /// - parameter pactVerificationService: Your customised `PactVerificationService`
+  /// - parameter errorReporter: Your customised `ErrorReporter`
   ///
   public init(
     provider: String,
@@ -40,8 +41,24 @@ open class MockService: NSObject {
   ///
   /// - parameter provider: Name of your provider (eg: Calculator API)
   /// - parameter consumer: Name of your consumer (eg: Calculator.app)
+  /// - parameter pactVerificationService: Your customised `PactVerificationService`
   ///
-  /// Use this initialiser to use the default PactVerificationService
+  /// Use this initialiser to use the default XCodeErrorReporter
+  ///
+  public convenience init(provider: String, consumer: String, pactVerificationService: PactVerificationService) {
+    self.init(provider: provider,
+              consumer: consumer,
+              pactVerificationService: pactVerificationService,
+              errorReporter: XCodeErrorReporter())
+  }
+
+  ///
+  /// Convenience Initializer
+  ///
+  /// - parameter provider: Name of your provider (eg: Calculator API)
+  /// - parameter consumer: Name of your consumer (eg: Calculator.app)
+  ///
+  /// Use this initialiser to use the default PactVerificationService and ErrorReporter
   ///
   @objc(initWithProvider: consumer:)
   public convenience init(provider: String, consumer: String) {


### PR DESCRIPTION
The existing initialisers in MockService are either the full init, or a convenience init which uses a default pactVerificationService and ErrorReporter. 

This PR adds a convenience init that allows you to inject a configured pactVerificationService but use the default XCodeErrorReporter.

My use case for this is in a project where I need to use multiple verification services for different APIs. In my tests I want to configure the correct server, but I don't want a custom ErrorReporter.