### PR TITLE
Add support for macCatalyst

### DIFF
--- a/PactConsumerSwift.xcodeproj/project.pbxproj
+++ b/PactConsumerSwift.xcodeproj/project.pbxproj
@@ -560,8 +560,8 @@
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/BrightFutures.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
+				"$(SRCROOT)/Carthage/Build/$(CARTHAGE_SUBFOLDER)/BrightFutures.framework",
+				"$(SRCROOT)/Carthage/Build/$(CARTHAGE_SUBFOLDER)/Nimble.framework",
 			);
 			name = "Copy Carthage Frameworks";
 			outputPaths = (

--- a/PactConsumerSwift.xcodeproj/project.pbxproj
+++ b/PactConsumerSwift.xcodeproj/project.pbxproj
@@ -16,9 +16,6 @@
 		A109FBC722CCBB55007B46F7 /* MockServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A109FBC622CCBB55007B46F7 /* MockServiceSpec.swift */; };
 		A109FBC822CCBB55007B46F7 /* MockServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A109FBC622CCBB55007B46F7 /* MockServiceSpec.swift */; };
 		A109FBC922CCBB55007B46F7 /* MockServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A109FBC622CCBB55007B46F7 /* MockServiceSpec.swift */; };
-		A109FBCB22CCC376007B46F7 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A109FBCA22CCC376007B46F7 /* OHHTTPStubs.framework */; };
-		A10EF4EC22E06D6200C4E9E7 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10EF4EB22E06D6200C4E9E7 /* OHHTTPStubs.framework */; };
-		A10EF4EE22E06D7800C4E9E7 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10EF4ED22E06D7800C4E9E7 /* OHHTTPStubs.framework */; };
 		A1B2BE9222D19924009B0837 /* ErrorCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2BE9122D19924009B0837 /* ErrorCapture.swift */; };
 		A1B2BE9322D19924009B0837 /* ErrorCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2BE9122D19924009B0837 /* ErrorCapture.swift */; };
 		A1B2BE9422D19924009B0837 /* ErrorCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2BE9122D19924009B0837 /* ErrorCapture.swift */; };
@@ -57,21 +54,6 @@
 		AD17A6701F74BB8400219F39 /* Matcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD17A64B1F74BA8A00219F39 /* Matcher.swift */; };
 		AD17A6711F74BB8400219F39 /* MockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD17A64C1F74BA8A00219F39 /* MockService.swift */; };
 		AD17A6721F74BB8400219F39 /* PactVerificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD17A64D1F74BA8A00219F39 /* PactVerificationService.swift */; };
-		ADC03E1B1F74C41B003FCA6A /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E181F74C41B003FCA6A /* BrightFutures.framework */; };
-		ADC03E1C1F74C41B003FCA6A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E191F74C41B003FCA6A /* Nimble.framework */; };
-		ADC03E1F1F74C492003FCA6A /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E181F74C41B003FCA6A /* BrightFutures.framework */; };
-		ADC03E201F74C492003FCA6A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E191F74C41B003FCA6A /* Nimble.framework */; };
-		ADC03E221F74C492003FCA6A /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E211F74C492003FCA6A /* Quick.framework */; };
-		ADC03E261F74C64F003FCA6A /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E231F74C64E003FCA6A /* BrightFutures.framework */; };
-		ADC03E271F74C64F003FCA6A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E241F74C64E003FCA6A /* Nimble.framework */; };
-		ADC03E2A1F74C68E003FCA6A /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E231F74C64E003FCA6A /* BrightFutures.framework */; };
-		ADC03E2B1F74C68E003FCA6A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E241F74C64E003FCA6A /* Nimble.framework */; };
-		ADC03E2F1F74C68E003FCA6A /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E2D1F74C68E003FCA6A /* Quick.framework */; };
-		ADC03E351F74C8A5003FCA6A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E301F74C8A5003FCA6A /* Nimble.framework */; };
-		ADC03E371F74C8A5003FCA6A /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E321F74C8A5003FCA6A /* BrightFutures.framework */; };
-		ADC03E391F74C8A5003FCA6A /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E341F74C8A5003FCA6A /* Quick.framework */; };
-		ADC03E3B1F74C8EE003FCA6A /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E321F74C8A5003FCA6A /* BrightFutures.framework */; };
-		ADC03E3C1F74C8EE003FCA6A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADC03E301F74C8A5003FCA6A /* Nimble.framework */; };
 		ADC03E3D1F74C920003FCA6A /* InteractionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD17A6511F74BAA900219F39 /* InteractionSpec.swift */; };
 		ADC03E3E1F74C920003FCA6A /* MatcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD17A6501F74BAA900219F39 /* MatcherSpec.swift */; };
 		ADC03E3F1F74C987003FCA6A /* OCAnimalServiceClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AD17A6541F74BAC700219F39 /* OCAnimalServiceClient.m */; };
@@ -106,9 +88,6 @@
 		A109FBA722CB6A6C007B46F7 /* XCodeErrorReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCodeErrorReporter.swift; sourceTree = "<group>"; };
 		A109FBA822CB6A6C007B46F7 /* ErrorReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorReporter.swift; sourceTree = "<group>"; };
 		A109FBC622CCBB55007B46F7 /* MockServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockServiceSpec.swift; sourceTree = "<group>"; };
-		A109FBCA22CCC376007B46F7 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
-		A10EF4EB22E06D6200C4E9E7 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/Mac/OHHTTPStubs.framework; sourceTree = "<group>"; };
-		A10EF4ED22E06D7800C4E9E7 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/tvOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		A1B2BE9122D19924009B0837 /* ErrorCapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorCapture.swift; sourceTree = "<group>"; };
 		A1B2BE9522D19949009B0837 /* RubyPactMockServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubyPactMockServiceStub.swift; sourceTree = "<group>"; };
 		AD17A5881F74AF5300219F39 /* PactConsumerSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PactConsumerSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -131,19 +110,6 @@
 		AD17A6521F74BAC600219F39 /* OCAnimalServiceClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCAnimalServiceClient.h; sourceTree = "<group>"; };
 		AD17A6531F74BAC700219F39 /* PactObjectiveCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PactObjectiveCTests.m; sourceTree = "<group>"; };
 		AD17A6541F74BAC700219F39 /* OCAnimalServiceClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCAnimalServiceClient.m; sourceTree = "<group>"; };
-		ADC03E181F74C41B003FCA6A /* BrightFutures.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BrightFutures.framework; path = Carthage/Build/iOS/BrightFutures.framework; sourceTree = "<group>"; };
-		ADC03E191F74C41B003FCA6A /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
-		ADC03E211F74C492003FCA6A /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
-		ADC03E231F74C64E003FCA6A /* BrightFutures.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BrightFutures.framework; path = Carthage/Build/Mac/BrightFutures.framework; sourceTree = "<group>"; };
-		ADC03E241F74C64E003FCA6A /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
-		ADC03E2C1F74C68E003FCA6A /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/Mac/Result.framework; sourceTree = "<group>"; };
-		ADC03E2D1F74C68E003FCA6A /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
-		ADC03E301F74C8A5003FCA6A /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
-		ADC03E311F74C8A5003FCA6A /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/tvOS/Result.framework; sourceTree = "<group>"; };
-		ADC03E321F74C8A5003FCA6A /* BrightFutures.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BrightFutures.framework; path = Carthage/Build/tvOS/BrightFutures.framework; sourceTree = "<group>"; };
-		ADC03E341F74C8A5003FCA6A /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
-		ADC03E421F74E68D003FCA6A /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/watchOS/Result.framework; sourceTree = "<group>"; };
-		ADC03E431F74E68D003FCA6A /* BrightFutures.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BrightFutures.framework; path = Carthage/Build/watchOS/BrightFutures.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,8 +117,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ADC03E1B1F74C41B003FCA6A /* BrightFutures.framework in Frameworks */,
-				ADC03E1C1F74C41B003FCA6A /* Nimble.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -160,11 +124,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A109FBCB22CCC376007B46F7 /* OHHTTPStubs.framework in Frameworks */,
 				AD17A5921F74AF5300219F39 /* PactConsumerSwift.framework in Frameworks */,
-				ADC03E1F1F74C492003FCA6A /* BrightFutures.framework in Frameworks */,
-				ADC03E221F74C492003FCA6A /* Quick.framework in Frameworks */,
-				ADC03E201F74C492003FCA6A /* Nimble.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,8 +132,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ADC03E261F74C64F003FCA6A /* BrightFutures.framework in Frameworks */,
-				ADC03E271F74C64F003FCA6A /* Nimble.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -181,11 +139,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A10EF4EC22E06D6200C4E9E7 /* OHHTTPStubs.framework in Frameworks */,
 				AD17A5B11F74AFB000219F39 /* PactConsumerSwift.framework in Frameworks */,
-				ADC03E2A1F74C68E003FCA6A /* BrightFutures.framework in Frameworks */,
-				ADC03E2B1F74C68E003FCA6A /* Nimble.framework in Frameworks */,
-				ADC03E2F1F74C68E003FCA6A /* Quick.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -193,8 +147,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ADC03E3B1F74C8EE003FCA6A /* BrightFutures.framework in Frameworks */,
-				ADC03E3C1F74C8EE003FCA6A /* Nimble.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -202,11 +154,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A10EF4EE22E06D7800C4E9E7 /* OHHTTPStubs.framework in Frameworks */,
 				AD17A5CD1F74AFC900219F39 /* PactConsumerSwift.framework in Frameworks */,
-				ADC03E371F74C8A5003FCA6A /* BrightFutures.framework in Frameworks */,
-				ADC03E351F74C8A5003FCA6A /* Nimble.framework in Frameworks */,
-				ADC03E391F74C8A5003FCA6A /* Quick.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -238,7 +186,6 @@
 				AD17A5EA1F74B03500219F39 /* Tests */,
 				AD17A5EB1F74B03D00219F39 /* PactConsumerObjCTests */,
 				AD17A5891F74AF5300219F39 /* Products */,
-				ADC03E171F74C2C0003FCA6A /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -315,29 +262,6 @@
 				AD17A64F1F74BAA900219F39 /* AnimalServiceClient.swift */,
 			);
 			path = PactConsumerSwiftTests;
-			sourceTree = "<group>";
-		};
-		ADC03E171F74C2C0003FCA6A /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				A109FBCA22CCC376007B46F7 /* OHHTTPStubs.framework */,
-				A10EF4EB22E06D6200C4E9E7 /* OHHTTPStubs.framework */,
-				A10EF4ED22E06D7800C4E9E7 /* OHHTTPStubs.framework */,
-				ADC03E321F74C8A5003FCA6A /* BrightFutures.framework */,
-				ADC03E431F74E68D003FCA6A /* BrightFutures.framework */,
-				ADC03E421F74E68D003FCA6A /* Result.framework */,
-				ADC03E301F74C8A5003FCA6A /* Nimble.framework */,
-				ADC03E341F74C8A5003FCA6A /* Quick.framework */,
-				ADC03E311F74C8A5003FCA6A /* Result.framework */,
-				ADC03E2D1F74C68E003FCA6A /* Quick.framework */,
-				ADC03E2C1F74C68E003FCA6A /* Result.framework */,
-				ADC03E231F74C64E003FCA6A /* BrightFutures.framework */,
-				ADC03E241F74C64E003FCA6A /* Nimble.framework */,
-				ADC03E211F74C492003FCA6A /* Quick.framework */,
-				ADC03E181F74C41B003FCA6A /* BrightFutures.framework */,
-				ADC03E191F74C41B003FCA6A /* Nimble.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -981,6 +905,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CARTHAGE_SUBFOLDER = iOS;
+				"CARTHAGE_SUBFOLDER[sdk=macosx*]" = macCatalyst;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1020,7 +946,7 @@
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/$(CARTHAGE_SUBFOLDER)",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -1059,6 +985,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CARTHAGE_SUBFOLDER = iOS;
+				"CARTHAGE_SUBFOLDER[sdk=macosx*]" = macCatalyst;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1098,7 +1026,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/$(CARTHAGE_SUBFOLDER)",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;


### PR DESCRIPTION
Removes all referenced frameworks because having them in FRAMEWORK_SEARCH_PATHS is enough. Introduce a new variable CARTHAGE_SUBFOLDER that is different in case of macOS, so a correct framework can be used in case of macCatalyst.