### PR TITLE
(fix) Backwards compatibility with Xcode 10.2

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
 github "Quick/Quick" ~> 2.0
-github "AliSoftware/OHHTTPStubs"
+github "AliSoftware/OHHTTPStubs" ~> 8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "AliSoftware/OHHTTPStubs" "8.0.0"
-github "Quick/Nimble" "v8.0.4"
+github "Quick/Nimble" "v8.0.5"
 github "Quick/Quick" "v2.2.0"

--- a/Sources/PactVerificationService.swift
+++ b/Sources/PactVerificationService.swift
@@ -186,7 +186,7 @@ private extension PactVerificationService {
 private extension PactVerificationService {
 
   var session: URLSession {
-    URLSession(configuration: URLSessionConfiguration.ephemeral)
+    return URLSession(configuration: URLSessionConfiguration.ephemeral)
   }
 
   func performNetworkRequest(for router: Router, completion: @escaping (Result<String, URLSession.APIServiceError>) -> Void) {
@@ -220,15 +220,15 @@ private extension PactVerificationService {
 private extension NSError {
 
   static func prepareWith(userInfo: [String: Any]) -> NSError {
-    NSError(domain: "error", code: 0, userInfo: userInfo)
+    return NSError(domain: "error", code: 0, userInfo: userInfo)
   }
 
   static func prepareWith(message: String) -> NSError {
-    NSError(domain: "error", code: 0, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("Error", value: message, comment: "")]) //swiftlint:disable:this line_length
+    return NSError(domain: "error", code: 0, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("Error", value: message, comment: "")]) //swiftlint:disable:this line_length
   }
 
   static func prepareWith(data: Data) -> NSError {
-    NSError(domain: "error", code: 0, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("Error", value: "\(String(data: data, encoding: .utf8) ?? "Failed to cast response Data into String")", comment: "")]) //swiftlint:disable:this line_length
+    return NSError(domain: "error", code: 0, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("Error", value: "\(String(data: data, encoding: .utf8) ?? "Failed to cast response Data into String")", comment: "")]) //swiftlint:disable:this line_length
   }
 
 }


### PR DESCRIPTION
This PR will fix the codebase to build and run with Xcode 10.2 for backwards compatibility:

1. re-introduce implicit returns
2. fix the OHTTPStubs to version 8 as version 9 breaks test implementation

Tested on local machine running Xcode 10.2 and Xcode 11.3