### PR TITLE
Make it so `testFunction` can throw

### DIFF
--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -176,7 +176,11 @@ open class MockService: NSObject {
             do {
               try testFunction { done() }
             } catch {
-              self.failWithLocation("Error thrown in test function (check build log): \(error.localizedDescription)", file: file, line: line)
+              self.failWithLocation(
+                "Error thrown in test function (check build log): \(error.localizedDescription)",
+                file: file,
+                line: line
+              )
               done()
             }
           case .failure(let error):

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -165,7 +165,7 @@ open class MockService: NSObject {
     _ file: FileString? = #file,
     line: UInt? = #line,
     timeout: TimeInterval = 30,
-    testFunction: @escaping (_ testComplete: @escaping () -> Void) -> Void
+    testFunction: @escaping (_ testComplete: @escaping () -> Void) throws -> Void
   ) {
     waitUntilWithLocation(timeout: timeout, file: file, line: line) { done in
       self
@@ -173,7 +173,12 @@ open class MockService: NSObject {
         .setup(self.interactions) { result in
           switch result {
           case .success:
-            testFunction { done() }
+            do {
+              try testFunction { done() }
+            } catch {
+              self.failWithLocation("Error thrown in test function (check build log): \(error.localizedDescription)", file: file, line: line)
+              done()
+            }
           case .failure(let error):
             self.failWithLocation("Error setting up pact: \(error.localizedDescription)", file: file, line: line)
             done()

--- a/Tests/MockServiceSpec.swift
+++ b/Tests/MockServiceSpec.swift
@@ -212,27 +212,18 @@ class MockServiceSpec: QuickSpec {
       }
     }
 
-    describe("test function throws") {
+    describe("when test function throws error") {
       beforeEach {
         pactServicePactStub!
           .clean(responseCode: 200, response: "Cleaned OK")
           .setupInteractions(responseCode: 200, response: "Setup succeeded")
       }
 
-      it("calls test function") {
-        var calledTestFunction = false
-        mockService!.run() { (testComplete) -> Void in
-          calledTestFunction = true
-          testComplete()
-        }
-        expect(calledTestFunction).to(equal(true))
-      }
-
       enum MockError: Error {
         case problem
       }
 
-      it("returns error message from error thrown by test function") {
+      it("returns message from thrown error") {
         mockService!.run() { _ -> Void in
           throw MockError.problem
         }

--- a/Tests/MockServiceSpec.swift
+++ b/Tests/MockServiceSpec.swift
@@ -211,5 +211,35 @@ class MockServiceSpec: QuickSpec {
         expect(pactServicePactStub!.writePactStub.requestExecuted).to(equal(true))
       }
     }
+
+    describe("test function throws") {
+      beforeEach {
+        pactServicePactStub!
+          .clean(responseCode: 200, response: "Cleaned OK")
+          .setupInteractions(responseCode: 200, response: "Setup succeeded")
+      }
+
+      it("calls test function") {
+        var calledTestFunction = false
+        mockService!.run() { (testComplete) -> Void in
+          calledTestFunction = true
+          testComplete()
+        }
+        expect(calledTestFunction).to(equal(true))
+      }
+
+      enum MockError: Error {
+        case problem
+      }
+
+      it("returns error message from error thrown by test function") {
+        mockService!.run() { _ -> Void in
+          throw MockError.problem
+        }
+        expect(errorCapturer!.message!.message).to(contain(
+          "Error thrown in test function (check build log):"
+        ))
+      }
+    }
   }
 }


### PR DESCRIPTION
Previously, running the MockService only took a non-throwing closure. This is place in which testers will place their networking requests. It is common for networking requests to throw, however. Not being able to throw in the test function meant testers had to catch and fail their tests on their own:

    myMockService.run(timeout: 10) { (testComplete) -> Void in
      do {
        try serviceClientUnderTest.getUsers( /* ... */ )
      } catch {
        XCTFail("error thrown: \(error.localizedDescription)")
      }
    }

It would be cleaner if `run` would accept a throwing function and fail the test itself. This would become:

    myMockService.run(timeout: 10) { (testComplete) -> Void in
      try serviceClientUnderTest.getUsers( /* ... */ )
    }

__NB:__ I have not made it so that the `run` function rethrows. This proved to be a challenge, and I have not completed it. It could done later on. The main difficulty was my understanding the nesting of call-backs. I wound up having to salt-and-pepper `try`, `throws`, and `rethrows` all over the place; ending up in trouble when `URLSession.dataTask` could not throw its errors, but captured the throwing test function. I have left the branch up: https://github.com/huwr/pact-consumer-swift/tree/huwr/throwing

Resolves #83