### PR TITLE
chore(build) Use xcbeautify for TravisCI build pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
-osx_image: xcode11.2
+os: osx
+osx_image: xcode11.3
 env:
   global:
     - IOS_FRAMEWORK_SCHEME="PactConsumerSwift iOS"
@@ -9,7 +10,7 @@ env:
     - secure: QmmEqePFeG6D1Qu0KrWI0w6LiwiY3V2qUWAHxQrSYFFPG4wJOZuHpwdk9NO45gOzPYxbkzXT9MynWFMs5pZKrIJCmQRkK5fNcDecwvNunsJEzBmvNYLhd0B4IKy2R1pBmKcDHPIYCzgpanPDAV7LhTXlGoUGk59+QL6qK8+hBQs=
     - secure: FpfacekFs93LkX9gerQUxQKIDTjBl2abp7ZQ/8L3DiJo4nMF7xEwUGeSDQMR+2hRqRWr/SdU59Lll5k10JBqWxAaLXDTUq3Lh3aamc4nc2PAN7yp+0aq9RQG5+PaLkfx+SLs5B/CjDiRRotZg/H/uMTRRFbkqydVtxiqGv94JOg=
   matrix:
-    - DESTINATION="OS=12.0,name=iPhone X"   SCHEME="$IOS_FRAMEWORK_SCHEME"       CARTHAGE_PLATFORM="iOS"
+    - DESTINATION="OS=13.3,name=iPhone 11"   SCHEME="$IOS_FRAMEWORK_SCHEME"       CARTHAGE_PLATFORM="iOS"
     - DESTINATION="OS=11.3,name=iPhone 8"   SCHEME="$IOS_FRAMEWORK_SCHEME"       CARTHAGE_PLATFORM="iOS"
     - DESTINATION="OS=11.0,name=Apple TV 4K (at 1080p)" SCHEME="$TVOS_FRAMEWORK_SCHEME" CARTHAGE_PLATFORM="tvOS"
     - DESTINATION="arch=x86_64"             SCHEME="$MACOS_FRAMEWORK_SCHEME"     CARTHAGE_PLATFORM="macOS"

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,6 @@
 tap 'pact-foundation/pact-ruby-standalone'
+tap 'thii/xcbeautify'
 brew 'carthage'
 brew 'swiftlint'
 brew 'pact-ruby-standalone'
+brew 'xcbeautify'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,17 +17,17 @@ defaults to iOS 11 on iPhone 8
 ### Running specific platform tests
 iOS 10.3 on iPhone 7:
 ```
-xcodebuild -project PactConsumerSwift.xcodeproj -scheme "PactConsumerSwift iOS" -destination "OS=10.3,name=iPhone 7" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
+xcodebuild -project PactConsumerSwift.xcodeproj -scheme "PactConsumerSwift iOS" -destination "OS=10.3,name=iPhone 7" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify;
 ```
 
 for macOS:
 ```
-xcodebuild -project PactConsumerSwift.xcodeproj -scheme "PactConsumerSwift macOS" -destination "arch=x86_64" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
+xcodebuild -project PactConsumerSwift.xcodeproj -scheme "PactConsumerSwift macOS" -destination "arch=x86_64" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify;
 ```
 
 for tvOS:
 ```
-xcodebuild -project PactConsumerSwift.xcodeproj -scheme PactConsumerSwift tvOS -destination OS=11.0,name=Apple TV 4K (at 1080p) -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
+xcodebuild -project PactConsumerSwift.xcodeproj -scheme PactConsumerSwift tvOS -destination OS=11.0,name=Apple TV 4K (at 1080p) -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify;
 ```
 
 #### Test CocoaPods

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,23 +3,27 @@ set -e
 
 if [[ -z "${PROJECT_NAME}" ]]; then
   PROJECT_NAME="PactConsumerSwift.xcodeproj";
-  DESTINATION="OS=13.0,name=iPhone Xʀ";
+  DESTINATION="OS=13.3,name=iPhone 11";
   SCHEME="PactConsumerSwift iOS";
   CARTHAGE_PLATFORM="iOS";
 fi
 
-carthage build --no-skip-current --platform $CARTHAGE_PLATFORM
+# Carthage - build dependencies
+carthage build --no-use-binaries --platform $CARTHAGE_PLATFORM 
 
 # SwiftPM
 echo "#### Testing DEBUG configuration for SwiftPM compatibility ####"
 swift build
 
-# Carthage - debug
+# Build and test - debug
 echo "#### Testing DEBUG configuration for scheme: $SCHEME, with destination: $DESTINATION ####"
-echo "Running: \"xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;\""
-set -o pipefail && xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;
+echo "Running: \"xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify\""
+set -o pipefail && xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify
 
-# Carthage - release
+# Build and test - release
 echo "#### Testing RELEASE configuration for scheme: $SCHEME, with destination: $DESTINATION ####"
-echo "Running: \"xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;\""
-set -o pipefail && xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;
+echo "Running: \"xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify\""
+set -o pipefail && xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify
+
+# Carthage - test that the lot builds for Carthage
+carthage build pact-consumer-swift --no-skip-current --no-use-binaries --platform $CARTHAGE_PLATFORM 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
 
-gem install xcpretty
 brew update && brew bundle
 carthage checkout

--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -52,7 +52,7 @@ if [ ! -f "${CONFIGFILE}" ]; then
 fi 
 
 # All hunky dory, run linting
-$BINARYFILE --config "${CONFIGFILE}" --strict
+$BINARYFILE --config "${CONFIGFILE}"
 
 # Finish the script
 exit 0


### PR DESCRIPTION
`xcpretty` tool does not seem to be working in our favour anymore on TravisCI when running `xcodebuild` commands.

Suggestion is to replace it with `xcbeautify`.

Changes:
- Replace `xcpretty` with `xcbeautify` for `xcodebuild` command,
- Remove `--no-skip-current` flag from the command that builds the dependencies (when `pact-consumer-swift` fails to build, TravisCI.org _hides_ the output in a `.log` instead of printing it in build console for developer to see what has happened),
- Add a `scripts/build.sh` step that tests the framework builds as a Carthage dependency,
- Remove `--strict` from Swiftlint command to allow the bundle to build.

This PR will resolve #90. 