### PR TITLE
chore: Update CI pipeline (#90)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,6 @@
-tap 'pact-foundation/pact-ruby-standalone'
+tap 'pact-foundation/pact-ruby-standalone', 'https://github.com/pact-foundation/homebrew-pact-ruby-standalone.git'
+tap 'thii/xcbeautify', 'https://github.com/thii/xcbeautify.git'
 brew 'carthage'
 brew 'swiftlint'
 brew 'pact-ruby-standalone'
+brew 'xcbeautify'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,17 +17,17 @@ defaults to iOS 11 on iPhone 8
 ### Running specific platform tests
 iOS 10.3 on iPhone 7:
 ```
-xcodebuild -project PactConsumerSwift.xcodeproj -scheme "PactConsumerSwift iOS" -destination "OS=10.3,name=iPhone 7" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
+xcodebuild -project PactConsumerSwift.xcodeproj -scheme "PactConsumerSwift iOS" -destination "OS=10.3,name=iPhone 7" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify;
 ```
 
 for macOS:
 ```
-xcodebuild -project PactConsumerSwift.xcodeproj -scheme "PactConsumerSwift macOS" -destination "arch=x86_64" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
+xcodebuild -project PactConsumerSwift.xcodeproj -scheme "PactConsumerSwift macOS" -destination "arch=x86_64" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify;
 ```
 
 for tvOS:
 ```
-xcodebuild -project PactConsumerSwift.xcodeproj -scheme PactConsumerSwift tvOS -destination OS=11.0,name=Apple TV 4K (at 1080p) -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
+xcodebuild -project PactConsumerSwift.xcodeproj -scheme PactConsumerSwift tvOS -destination OS=11.0,name=Apple TV 4K (at 1080p) -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify;
 ```
 
 #### Test CocoaPods

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,8 @@ if [[ -z "${PROJECT_NAME}" ]]; then
   CARTHAGE_PLATFORM="iOS";
 fi
 
-carthage build --no-skip-current --platform $CARTHAGE_PLATFORM
+# Build Carthage dependencies
+carthage build --platform $CARTHAGE_PLATFORM
 
 # SwiftPM
 echo "#### Testing DEBUG configuration for SwiftPM compatibility ####"
@@ -16,10 +17,13 @@ swift build
 
 # Carthage - debug
 echo "#### Testing DEBUG configuration for scheme: $SCHEME, with destination: $DESTINATION ####"
-echo "Running: \"xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;\""
-set -o pipefail && xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;
+echo "Running: \"xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify\""
+set -o pipefail && xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify
 
 # Carthage - release
 echo "#### Testing RELEASE configuration for scheme: $SCHEME, with destination: $DESTINATION ####"
-echo "Running: \"xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;\""
-set -o pipefail && xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;
+echo "Running: \"xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify\""
+set -o pipefail && xcodebuild -project $PROJECT_NAME -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcbeautify
+
+# Test the lot that it builds for Carthage
+carthage build --no-skip-current --platform $CARTHAGE_PLATFORM

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
 
-gem install xcpretty
 brew update && brew bundle
 carthage checkout

--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -49,7 +49,7 @@ fi
 # Check whether Swiftlint Config file exists
 if [ ! -f "${CONFIGFILE}" ]; then
   throw_not_found $ERROR "${CONFIGFILE}" ""
-fi 
+fi
 
 # All hunky dory, run linting
 $BINARYFILE --config "${CONFIGFILE}" --strict


### PR DESCRIPTION
`xcpretty` tool does not seem to be working in our favour anymore on TravisCI when running `xcodebuild` commands.

Suggestion is to replace it with `xcbeautify`.

Changes:

- Replace `xcpretty` with `xcbeautify` for `xcodebuild` command 
- Remove `--no-skip-current` flag from the command that builds the dependencies for `pact-consumer-swift`. If `pact-consumer-swift` fails to build before even running tests etc, TravisCI.org hides the output in a _hidden_ .log instead of printing it in the console for developer to see what has happened and quickly know how to fix it,
- ~Add a `scripts/build.sh` step that tests the framework builds as a Carthage dependency. This will try and build all the dependencies including `pact-consumer-swift` framework for Carthage.~ This has been introduced with `c02537f6`
- Remove `--strict` from Swiftlint command to allow the bundle to build if only warnings (below threshold number) are found. This will allow more contributors to share their code while not be blocked by (sometimes) trivial cosmetic issues,
- ~Set the latest available TravisCI Xcode environment (11.2 -> 11.3). To stay aligned with the times we live in.~ This has been introduced with `c02537f6`
- Set the latest available TravisCI iPhone simulator to run `xcodebuild` against (iPhone X -> iPhone ~11~ 8 (introduced with `c02537f6`)). ~Using the latest stable Simulator available so we can fail sooner and fix it.~ 

This PR will resolve #90 