### PR TITLE
maintenance: Update Quick and Nimble versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11.4
+osx_image: xcode11.7
 env:
   global:
     - IOS_FRAMEWORK_SCHEME="PactConsumerSwift iOS"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Quick/Nimble" ~> 8.0
+github "Quick/Nimble" ~> 9.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "Quick/Quick" ~> 2.0
+github "Quick/Quick" ~> 3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v8.0.5"
-github "Quick/Quick" "v2.2.0"
+github "Quick/Nimble" "v9.0.0"
+github "Quick/Quick" "v3.0.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "33682c2f6230c60614861dfc61df267e11a1602f",
-          "version": "2.2.0"
+          "revision": "0038bcbab4292f3b028632556507c124e5ba69f3",
+          "version": "3.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     .library(name: "PactConsumerSwift", targets: ["PactConsumerSwift"])
   ],
   dependencies: [
-    .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
-    .package(url: "https://github.com/Quick/Quick.git", from: "2.2.0")
+    .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
+    .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0")
   ],
   targets: [
     .target(


### PR DESCRIPTION
These changes update the dependencies' versions.

Carthage already has Quick in `Cartfile.private`.
Looked into removing Quick from `Package.swift`, and dependency is used only in the test target. But the way SPM pulls in all the dependencies is per project in one spot. Might be possible with specific scripts/methods? Would require quite a bit of fiddling around and time which I don't have time for. Perhaps we could open up a GitHub issue for it.

Tested and passed:
- [x] fork with Xcode 11.7 (Carthage) 
- [x] Xcode 12 (SPM) with a demo project as identified in #101
- [x] Travisci on the fork https://travis-ci.org/github/surpher/pact-consumer-swift/builds/737346366

Resolves #101 