### PR TITLE
tech: Update CI workflow to trigger Demo Projects' build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,11 +112,6 @@ jobs:
     name: "Build example projects"
     runs-on: ubuntu-20.04
 
-    env:
-      AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
-      GH_BUILD_CHILDREN_TOKEN: ${{ secrets.GH_BUILD_CHILDREN_TOKEN }}
-      COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -126,3 +121,7 @@ jobs:
       - name: Trigger Demo Project builds
         run: |
           scripts/build_children.sh
+        env:
+          AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
+          GH_BUILD_CHILDREN_TOKEN: ${{ secrets.GH_BUILD_CHILDREN_TOKEN }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,6 @@ jobs:
           echo "⚠️  Skipping \"swift test\" as no test target is defined in \"Package.swift\" (https://github.com/DiUS/pact-consumer-swift/commit/229f35d63a547f492c7ba9e177ac8d7b685e7a7f)"
 
   test_carthage:
-    needs: [test_xcodebuild]
     name: "Test Carthage dependency"
     runs-on: macOS-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,8 @@ jobs:
 
     env:
       AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
+      GH_BUILD_CHILDREN_TOKEN: ${{ secrets.GH_BUILD_CHILDREN_TOKEN }}
+      COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -84,7 +84,6 @@ jobs:
           echo "⚠️  Skipping \"swift test\" as no test target is defined in \"Package.swift\" (https://github.com/DiUS/pact-consumer-swift/commit/229f35d63a547f492c7ba9e177ac8d7b685e7a7f)"
 
   test_carthage:
-    needs: [test_xcodebuild]
     name: "Test Carthage dependency"
     runs-on: macOS-10.15
 

--- a/scripts/build_children.sh
+++ b/scripts/build_children.sh
@@ -23,7 +23,7 @@ function triggerGitHubActionsBuild {
 	-H "Accept: application/vnd.github.everest-preview+json" \
 	-H "Content-Type: application/json" \
 	-u ${GITHUB_AUTH_TOKEN} \
-	--data "{\"event_type\":\"pact-consumer-swift - ${COMMIT_MESSAGE}\"}"
+	--data '{"event_type":"triggered ${COMMIT_MESSAGE}"}'
 }
 
 # GitHub Actions

--- a/scripts/build_children.sh
+++ b/scripts/build_children.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-set -eu
+set -xeu
 set -o pipefail
 
-TRAVISCI_AUTH_TOKEN=${AUTH_TOKEN:="invalid"}
-GITHUB_AUTH_TOKEN=${GH_BUILD_CHILDREN_TOKEN:="invalid"}
+TRAVISCI_AUTH_TOKEN=${AUTH_TOKEN:-"invalid_travis_ci_token"}
+GITHUB_AUTH_TOKEN=${GH_BUILD_CHILDREN_TOKEN:-"invalid_github_token"}
 COMMIT_MESSAGE=${COMMIT_MESSAGE:="repository_dispatched"}
 
 function triggerTravisCIBuild {
@@ -13,7 +13,7 @@ function triggerTravisCIBuild {
     -H "Accept: application/json" \
     -H "Travis-API-Version: 3" \
     -H "Authorization: token ${TRAVISCI_AUTH_TOKEN}" \
-    -d "{"request": {"branch":"master"}}" \
+    -d "{\"request\": {\"branch\":\"master\"}}" \
     https://api.travis-ci.org/repo/$1/requests
 }
 
@@ -22,7 +22,7 @@ function triggerGitHubActionsBuild {
 	https://api.github.com/repos/$1/dispatches \
 	-H "Accept: application/vnd.github.everest-preview+json" \
 	-H "Content-Type: application/json" \
-	-H "Authorization: token $GITHUB_AUTH_TOKEN" \
+	-u ${GITHUB_AUTH_TOKEN} \
 	--data "{\"event_type\":\"pact-consumer-swift - ${COMMIT_MESSAGE}\"}"
 }
 

--- a/scripts/build_children.sh
+++ b/scripts/build_children.sh
@@ -23,7 +23,7 @@ function triggerGitHubActionsBuild {
 	-H "Accept: application/vnd.github.everest-preview+json" \
 	-H "Content-Type: application/json" \
 	-u ${GITHUB_AUTH_TOKEN} \
-	--data '{"event_type":"triggered ${COMMIT_MESSAGE}"}'
+	--data "{\"event_type\":\"triggered ${COMMIT_MESSAGE}\"}"
 }
 
 # GitHub Actions

--- a/scripts/build_children.sh
+++ b/scripts/build_children.sh
@@ -1,21 +1,36 @@
 #!/bin/bash
 
-body='{
-"request": {
-"branch":"master"
-}}'
+set -eu
+set -o pipefail
 
-function triggerBuild {
-  curl -s -X POST \
+TRAVISCI_AUTH_TOKEN=${AUTH_TOKEN:="invalid"}
+GITHUB_AUTH_TOKEN=${GH_BUILD_CHILDREN_TOKEN:="invalid"}
+COMMIT_MESSAGE=${COMMIT_MESSAGE:="repository_dispatched"}
+
+function triggerTravisCIBuild {
+  curl -s -X POST --silent --show-error --fail \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
     -H "Travis-API-Version: 3" \
-    -H "Authorization: token $AUTH_TOKEN" \
-    -d "$body" \
+    -H "Authorization: token ${TRAVISCI_AUTH_TOKEN}" \
+    -d "{"request": {"branch":"master"}}" \
     https://api.travis-ci.org/repo/$1/requests
 }
 
-triggerBuild andrewspinks%2FPactObjectiveCExample
-triggerBuild andrewspinks%2FPactSwiftExample
-triggerBuild surpher%2FPactSwiftPMExample
-triggerBuild surpher%2FPactMacOSExample
+function triggerGitHubActionsBuild {
+	curl -X POST --silent --show-error --fail \
+	https://api.github.com/repos/$1/dispatches \
+	-H "Accept: application/vnd.github.everest-preview+json" \
+	-H "Content-Type: application/json" \
+	-H "Authorization: token $GITHUB_AUTH_TOKEN" \
+	--data "{\"event_type\":\"pact-consumer-swift - ${COMMIT_MESSAGE}\"}"
+}
+
+# GitHub Actions
+# - <name> and <repo> must be lower-case!
+triggerGitHubActionsBuild surpher/pactswiftpmexample
+triggerGitHubActionsBuild surpher/pactmacosexample
+
+# TravisCI
+triggerTravisCIBuild andrewspinks%2FPactObjectiveCExample
+triggerTravisCIBuild andrewspinks%2FPactSwiftExample

--- a/scripts/build_children.sh
+++ b/scripts/build_children.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -xeu
+set -eu
 set -o pipefail
 
 TRAVISCI_AUTH_TOKEN=${AUTH_TOKEN:-"invalid_travis_ci_token"}


### PR DESCRIPTION
Updates the `build_children.sh` script and `build.yml` workflow to trigger builds in demo projects' repos and fails with non-zero when a `curl` commands fail.

# 📝 Summary of Changes

Changes proposed in this pull request:

- Rename `triggerBuild` method to `triggerTravisCIBuild` - will be easier to remove/update once all demo projects are moved away from TravisCI
- Add `triggerGitHubActionsBuild` (auth token has been added to the secrets in this repo)
- Updates the arguments for `triggerGitHubActionsBuild`
- Makes the script/build fail if any of the `curl` requests fail
- Runs jobs concurrently (except `build_children`) to shave off a couple of minutes on build times

# 🧐🗒 Reviewer Notes

- The token for GitHub has been added to this repo's `secrets`

## 🔨 How To Test

- [ ] CI for this PR passes all required checks
- [ ] Demo project's build triggered in GitHub Actions for [`PactMacOSExample`](https://github.com/surpher/PactMacOSExample/actions?query=workflow%3ABuild)
- [ ] Demo project's build triggered in GitHub Actions for [`PactSwiftPMExample`](https://github.com/surpher/PactSwiftPMExample/actions?query=workflow%3ABuild)
- [ ] Build title in above demo projects is postfixed with the commit message
- [ ] Demo project's build triggered in TravisCI for [`PactSwiftExample`](https://travis-ci.org/andrewspinks/PactSwiftExample) 
- [ ] Demo project's build triggered in TravisCI for [`PactObjectiveCExample`](https://travis-ci.org/github/andrewspinks/PactObjectiveCExample)