### PR TITLE
fix: Truncate message when triggering example project builds

### DIFF
--- a/scripts/build_children.sh
+++ b/scripts/build_children.sh
@@ -6,6 +6,7 @@ set -o pipefail
 TRAVISCI_AUTH_TOKEN=${AUTH_TOKEN:-"invalid_travis_ci_token"}
 GITHUB_AUTH_TOKEN=${GH_BUILD_CHILDREN_TOKEN:-"invalid_github_token"}
 COMMIT_MESSAGE=${COMMIT_MESSAGE:="repository_dispatched"}
+COMMIT_MESSAGE_FIRST_LINE_ONLY=`echo "${COMMIT_MESSAGE}" | head -1`
 
 function triggerTravisCIBuild {
   curl -s -X POST --silent --show-error --fail \
@@ -23,7 +24,7 @@ function triggerGitHubActionsBuild {
 	-H "Accept: application/vnd.github.everest-preview+json" \
 	-H "Content-Type: application/json" \
 	-u ${GITHUB_AUTH_TOKEN} \
-	--data "{\"event_type\":\"triggered ${COMMIT_MESSAGE}\"}"
+	--data "{\"event_type\":\"triggered ${COMMIT_MESSAGE_FIRST_LINE_ONLY}\"}"
 }
 
 # GitHub Actions


### PR DESCRIPTION
GitHub Actions env `github.event.head_commit.message` takes the complete commit message. When passing it to the `curl` command, the curl command fails when message contains multiple lines.

With this fix only the first line of the commit message is used and passed to the demo projects’ GitHub Actions build run name (`event_type`).