### PR TITLE
fix: Repair tvOS scheme and improve exemptions in URLSessionDelegate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,9 @@ jobs:
             ${{ runner.os }}-pact-
             ${{ runner.os }}-
 
+      - name: Use Xcode 12.2
+        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
+
       - name: Prepare the tools
         run: |
           scripts/install_deps.sh
@@ -94,6 +97,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pact-
             ${{ runner.os }}-
+
+      - name: Use Xcode 12.2
+        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
 
       - name: Prepare Tools
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,6 +44,9 @@ jobs:
             ${{ runner.os }}-pact-
             ${{ runner.os }}-
 
+      - name: Use Xcode 12.2
+        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
+
       - name: Prepare the tools
         run: |
           scripts/install_deps.sh
@@ -85,6 +88,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pact-
             ${{ runner.os }}-
+
+      - name: Use Xcode 12.2
+        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
 
       - name: Prepare Tools
         run: |

--- a/.github/workflows/pull_request_xcode11_6.yml
+++ b/.github/workflows/pull_request_xcode11_6.yml
@@ -51,8 +51,7 @@ jobs:
       # Tools referenced in install_deps.sh script require Xcode 12.2 on macOS 10.15.
       - name: Prepare the tools
         run: |
-          brew update && brew bundle
-          carthage checkout
+          scripts/install_deps.sh
 
       # Manually running xcodebuild instead of scripts/build.sh
       # Tools referenced in install_deps.sh script require Xcode 12.2 on macOS 10.15.

--- a/.github/workflows/pull_request_xcode11_6.yml
+++ b/.github/workflows/pull_request_xcode11_6.yml
@@ -107,8 +107,7 @@ jobs:
 
       - name: Prepare Tools
         run: |
-          brew update && brew bundle
-          carthage checkout
+          scripts/install_deps.sh
 
       - name: Carthage build
         run: |

--- a/PactConsumerSwift.xcodeproj/project.pbxproj
+++ b/PactConsumerSwift.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		A1B2BE9722D19949009B0837 /* RubyPactMockServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2BE9522D19949009B0837 /* RubyPactMockServiceStub.swift */; };
 		A1B2BE9822D19949009B0837 /* RubyPactMockServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2BE9522D19949009B0837 /* RubyPactMockServiceStub.swift */; };
 		AD01EDB61F74BF4A00827C66 /* InteractionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD17A6511F74BAA900219F39 /* InteractionSpec.swift */; };
+		AD0AE27625CB4BD60072429D /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD0AE27425CB4BD60072429D /* Nimble.framework */; };
+		AD0AE27725CB4BD60072429D /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD0AE27525CB4BD60072429D /* Quick.framework */; };
+		AD0AE29925CB4FD90072429D /* Nimble.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = AD0AE27425CB4BD60072429D /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AD0AE29A25CB4FD90072429D /* Quick.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = AD0AE27525CB4BD60072429D /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AD17A5921F74AF5300219F39 /* PactConsumerSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD17A5881F74AF5300219F39 /* PactConsumerSwift.framework */; };
 		AD17A5991F74AF5300219F39 /* PactConsumerSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = AD17A58B1F74AF5300219F39 /* PactConsumerSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AD17A5B11F74AFB000219F39 /* PactConsumerSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD17A5A81F74AFB000219F39 /* PactConsumerSwift.framework */; };
@@ -205,6 +209,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD17A5CD1F74AFC900219F39 /* PactConsumerSwift.framework in Frameworks */,
+				AD0AE27625CB4BD60072429D /* Nimble.framework in Frameworks */,
+				AD0AE27725CB4BD60072429D /* Quick.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -214,6 +220,8 @@
 		93D579282418758700D480BC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AD0AE27425CB4BD60072429D /* Nimble.framework */,
+				AD0AE27525CB4BD60072429D /* Quick.framework */,
 				93D579312418759900D480BC /* XCTest.framework */,
 				93D5792D2418759000D480BC /* XCTest.framework */,
 				93D579292418758700D480BC /* XCTest.framework */,
@@ -463,7 +471,8 @@
 				AD17A5C81F74AFC900219F39 /* Sources */,
 				AD17A5C91F74AFC900219F39 /* Frameworks */,
 				AD17A5CA1F74AFC900219F39 /* Resources */,
-				AD17A62D1F74B6F700219F39 /* Copy Carthage Frameworks */,
+				AD17A62D1F74B6F700219F39 /* Copy Carthage Frameworks - DISABLED */,
+				AD0AE28A25CB4F5E0072429D /* Copy Carthage Frameworks */,
 				ADB5B72C22C4EDDC00301FB0 /* Check Dependencies */,
 			);
 			buildRules = (
@@ -644,7 +653,7 @@
 			shellPath = /bin/sh;
 			shellScript = "PATH=/usr/local/bin:$PATH\n\ncarthage copy-frameworks\n";
 		};
-		AD17A62D1F74B6F700219F39 /* Copy Carthage Frameworks */ = {
+		AD17A62D1F74B6F700219F39 /* Copy Carthage Frameworks - DISABLED */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -653,12 +662,12 @@
 				"$(SRCROOT)/Carthage/Build/tvOS/Nimble.framework",
 				"$(SRCROOT)/Carthage/Build/tvOS/Quick.framework",
 			);
-			name = "Copy Carthage Frameworks";
+			name = "Copy Carthage Frameworks - DISABLED";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "PATH=/usr/local/bin:$PATH\ncarthage copy-frameworks\n";
+			shellScript = "PATH=/usr/local/bin:$PATH\n# Not supported based on https://github.com/Carthage/Carthage#adding-frameworks-to-unit-tests-or-a-framework\n# carthage copy-frameworks\n";
 		};
 		ADB5B72A22C4EDB600301FB0 /* Check Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Sources/PactVerificationService.swift
+++ b/Sources/PactVerificationService.swift
@@ -216,7 +216,7 @@ extension PactVerificationService: URLSessionDelegate {
     guard
       allowInsecureCertificates,
       challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-      challenge.protectionSpace.host.contains("localhost"),
+      ["localhost", "127.0.0.1", "0.0.0.0"].contains(where: challenge.protectionSpace.host.contains),
       let serverTrust = challenge.protectionSpace.serverTrust
        else {
         completionHandler(.performDefaultHandling, nil)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,6 +19,7 @@ SCRIPTS_DIR="${BASH_SOURCE[0]%/*}"
 
 # Build Carthage dependencies
 $SCRIPTS_DIR/carthage_xcode12 update --platform $CARTHAGE_PLATFORM
+# carthage update --platform $CARTHAGE_PLATFORM
 
 # Carthage - debug
 echo "#### Testing scheme: $SCHEME, with destination: $DESTINATION ####"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,11 @@ if [[ -z "${PROJECT_NAME}" ]]; then
 		DESTINATION="arch=x86_64";
 		SCHEME="PactConsumerSwift macOS";
 		CARTHAGE_PLATFORM="macos";
+	elif [[ "$*" == "tvos" ]] || [[ "$*" == "tvos" ]]; then
+		PROJECT_NAME="PactConsumerSwift.xcodeproj";
+		DESTINATION="OS=14.2,name=Apple TV 4K (at 1080p)";
+		SCHEME="PactConsumerSwift tvOS";
+		CARTHAGE_PLATFORM="tvos";
  	else
 		PROJECT_NAME="PactConsumerSwift.xcodeproj";
 		DESTINATION="OS=14.2,name=iPhone 12 Pro";

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-set -eu
 
 # GitHub Hosted runners are complaining about re-installing Swiftlint using brew.
 if [[ "$CI" == true ]]; then
 	# Explicitly install only pact-ruby-standalone and xcbeautify, other tools are already installed on the GitHub hosted runner
-	brew tap 'pact-foundation/pact-ruby-standalone', 'https://github.com/pact-foundation/homebrew-pact-ruby-standalone.git'
-	brew tap 'thii/xcbeautify', 'https://github.com/thii/xcbeautify.git'
+	brew tap 'pact-foundation/pact-ruby-standalone'
+	brew tap 'thii/xcbeautify'
 	brew install 'pact-ruby-standalone'
 	brew install 'xcbeautify'
 else


### PR DESCRIPTION
Adds more variants of `localhost` to `URLSessionDelegate` so that `PactVerificationService` can talk to an unsecure mock-server. 

It appears that `https://localhost` no longer triggers the delegate method where we could allow connections to hosts with self-signed certificates. Instantiating `PactVerificationService` on `localhost` with allowing self signed certificates started failing when trying to connect to `pact-ruby-standalone`.
Using `127.0.0.1` works fine, provided the IP is in the delegate method and set to allow connections.

Resolves the issue that uncovered this drawback: #114.

In order to get it building on CI, the following clean-up tasks have been done:
- disable `copy-frameworks` build phase in tvOS test target as this step is irrelevant in test targets
- links the dependencies in tvOS test target and adds a build phase step to link those dependencies
- clean up the workflows to always use the improved `install_deps.sh`
- force use of Xcode 12.2 so selected simulator versions in the matrix match the ones installed on the build agent
- adds the option to run `build.sh` script with `tvOS` target