### PR TITLE
chore: Allow insecure connections on 127.0.0.1

### DIFF
--- a/Sources/PactVerificationService.swift
+++ b/Sources/PactVerificationService.swift
@@ -216,7 +216,7 @@ extension PactVerificationService: URLSessionDelegate {
     guard
       allowInsecureCertificates,
       challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-      challenge.protectionSpace.host.contains("localhost"),
+      ["localhost", "127.0.0.1", "0.0.0.0"].contains(where: challenge.protectionSpace.host.contains),
       let serverTrust = challenge.protectionSpace.serverTrust
        else {
         completionHandler(.performDefaultHandling, nil)


### PR DESCRIPTION
For some yet-unknown reason `URLSessionDelegate` isn't called if the baseURL is set to `https://localhost`. 
Adding `127.0.0.1` and `0.0.0.0` to the allow list when trying to connect over SSL where provider is exposing its endpoints using a self-signed certificate. This will enable users to actually set up the `mockService` and `.run()` the Pact tests against mock-server.

This way `mockService` can be instantiated with using:

```swift
PactVerificationService(url: "https://127.0.0.1", port: 1234, allowInsecureCertificates: true)
```

This was raised in #114 