### PR TITLE
Update Package.swift to set minimum supported iOS version to 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "PactConsumerSwift",
   platforms: [
-    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9)
+    .macOS(.v10_10), .iOS(.v9), .tvOS(.v9)
   ],
   products: [
     .library(name: "PactConsumerSwift", targets: ["PactConsumerSwift"])


### PR DESCRIPTION
This aligns the Package.swift with the Cocoapods manifest, which also specifies a minimum iOS version of 9

This commit resolves issue #122
(https://github.com/DiUS/pact-consumer-swift/issues/122)