### PR TITLE
fix: Query parameter url encoding

### DIFF
--- a/Sources/Interaction.swift
+++ b/Sources/Interaction.swift
@@ -63,12 +63,8 @@ public class Interaction: NSObject {
   /// - Returns: An `Interaction` object
   ///
   /// - Warning:
-  ///  When `query` parameter is provided as a `String` it is **not** percentage encoded to present a valid URL.
-  ///  This allows you to prepare a valid URL query such as:
-  ///
-  ///      ?someKey=value%20with%20space&anotherKey=anotherValue
-  ///
-  ///  Only when providing a query parameter as a `Dictionary<String, String>` the keys and values are percentage encoded.
+  ///  Only spaces are percentage encoded if found in `query` parameters when
+  ///  provided as type `String` or `Dictionary<String, String>`.
   ///
   @objc(withRequestHTTPMethod: path: query: headers: body:)
   @discardableResult
@@ -85,9 +81,11 @@ public class Interaction: NSObject {
       request["body"] = bodyValue
     }
     if let queryValue = query {
-      if let queryValue = queryValue as? [String: String] {
+      if let queryValue = queryValue as? String {
+        request["query"] = queryValue.replacingOccurrences(of: " ", with: "%20")
+      } else if let queryValue = queryValue as? [String: String] {
         request["query"] = queryValue
-          .map { "\($0.key.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) ?? "")=\($0.value.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) ?? "")" } // swiftlint:disable:this line_length
+          .map { "\($0.key.replacingOccurrences(of: " ", with: "%20"))=\($0.value.replacingOccurrences(of: " ", with: "%20"))" }
           .joined(separator: "&")
 
       } else {

--- a/Sources/Interaction.swift
+++ b/Sources/Interaction.swift
@@ -82,10 +82,10 @@ public class Interaction: NSObject {
     }
     if let queryValue = query {
       if let queryValue = queryValue as? String {
-        request["query"] = queryValue.replacingOccurrences(of: " ", with: "%20")
+        request["query"] = queryValue.withPercentageEncodedSpaces()
       } else if let queryValue = queryValue as? [String: String] {
         request["query"] = queryValue
-          .map { "\($0.key.replacingOccurrences(of: " ", with: "%20"))=\($0.value.replacingOccurrences(of: " ", with: "%20"))" }
+          .map { "\($0.key.withPercentageEncodedSpaces())=\($0.value.withPercentageEncodedSpaces())" }
           .joined(separator: "&")
 
       } else {
@@ -163,4 +163,12 @@ public class Interaction: NSObject {
       return "get"
     }
   }
+}
+
+private extension String {
+
+  func withPercentageEncodedSpaces() -> String {
+    self.replacingOccurrences(of: " ", with: "%20")
+  }
+
 }

--- a/Tests/PactConsumerSwiftTests/PactSpecs.swift
+++ b/Tests/PactConsumerSwiftTests/PactSpecs.swift
@@ -55,17 +55,38 @@ class PactSwiftSpec: QuickSpec {
       }
 
       describe("With query params") {
-        it("should return animals living in water") {
+
+        it("as string should return animals living in water") {
           animalMockService!.given("an alligator exists")
-                            .uponReceiving("a request for animals living in water")
-                            .withRequest(method:.GET, path: "/animals", query: ["live": "water"])
+                            .uponReceiving("a request for animals living in water with query string")
+                            .withRequest(method:.GET, path: "/animals", query: "live=in bayou swamp")
                             .willRespondWith(status: 200,
                                              headers: ["Content-Type": "application/json"],
                                              body: [ ["name": "Mary", "type": "alligator"] ] )
 
           //Run the tests
-          animalMockService!.run { (testComplete) -> Void in
-            animalServiceClient!.findAnimals(live: "water", response: {
+          animalMockService!.run(timeout: 1) { (testComplete) -> Void in
+            animalServiceClient!.findAnimals(live: "in bayou swamp", response: {
+              (response) in
+              expect(response.count).to(equal(1))
+              let name = response[0].name
+              expect(name).to(equal("Mary"))
+              testComplete()
+            })
+          }
+        }
+
+        it("as dictionary should return animals living in water") {
+          animalMockService!.given("an alligator exists")
+                            .uponReceiving("a request for animals living in water")
+                            .withRequest(method:.GET, path: "/animals", query: ["live": "on land"])
+                            .willRespondWith(status: 200,
+                                             headers: ["Content-Type": "application/json"],
+                                             body: [ ["name": "Mary", "type": "alligator"] ] )
+
+          //Run the tests
+          animalMockService!.run(timeout: 1) { (testComplete) -> Void in
+            animalServiceClient!.findAnimals(live: "on land", response: {
               (response) in
               expect(response.count).to(equal(1))
               let name = response[0].name

--- a/Tests/PactConsumerSwiftTests/PactSpecs.swift
+++ b/Tests/PactConsumerSwiftTests/PactSpecs.swift
@@ -59,14 +59,14 @@ class PactSwiftSpec: QuickSpec {
         it("as string should return animals living in water") {
           animalMockService!.given("an alligator exists")
                             .uponReceiving("a request for animals living in water with query string")
-                            .withRequest(method:.GET, path: "/animals", query: "live=in bayou swamp")
+                            .withRequest(method:.GET, path: "/animals", query: "live=in%20bayou swamp")
                             .willRespondWith(status: 200,
                                              headers: ["Content-Type": "application/json"],
                                              body: [ ["name": "Mary", "type": "alligator"] ] )
 
           //Run the tests
           animalMockService!.run(timeout: 1) { (testComplete) -> Void in
-            animalServiceClient!.findAnimals(live: "in bayou swamp", response: {
+            animalServiceClient!.findAnimals(live: "in bayou swamp", response: { // pact-consumer-swift's network request task percentage encodes the request being made
               (response) in
               expect(response.count).to(equal(1))
               let name = response[0].name


### PR DESCRIPTION
When `query` parameter is provided as a `String` or `Dictionary` of `[String: String]` it replaces occurrences of space characters with `%20`. Added a `warning` to the documentation comment about it and when providing a `Matcher` for a query parameter, the same character occurrence replacement does not occur.

Because the method signature  takes `query = Any?` it would not be wise to forcefully percentage encode all values. For example, if an existing test is providing a valid query parameter (eg: `lives=on%20land`) already, then the result would be the `%` sign would be encoded into `%25` and would not represent the intended url. The same percentage encoding is applied in ruby-mock-service if `%20` value is provided, the result in contract ends up being 
`%2520`.


Changes in this PR update the `Interaction.withRequest(method: path: query: headers: body)` method and adds/updates tests to validate the change. 

Test:
```swift
.withRequest(
  method: .GET, 
  path: "/animals", 
  query: ["live": "in%20bayou swamp"]
)
```

The result of the test in the .json file:

```json
"request": {
    "method": "get",
    "path": "/animals",
    "query": "live=in%20bayou%20swamp"
},
```

Resolves #125 